### PR TITLE
add GCE documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Cloud deployments
 The following example demonstrates how to create, and deploy, a UEFI-bootable image
 for Google Compute Engine:
 
-* [Google-Compute-Engine-deployments](https://github.com/usbarmory/go-boot/wiki/Google-Compute-Engine-deployments)
+* [Google-Compute-Engine](https://github.com/usbarmory/go-boot/wiki/Google-Compute-Engine)
 
 License
 =======


### PR DESCRIPTION
Add documentation on how create and deploy a go-boot image to Google Compute Engine