### PR TITLE
uefi: fix callFn stack alignment for odd stack-argument counts

### DIFF
--- a/uefi/uefi_amd64.s
+++ b/uefi/uefi_amd64.s
@@ -63,8 +63,8 @@ TEXT ·callFn(SB),NOSPLIT,$0-48
 
 	MOVQ	R13, R14
 	ANDQ	$1, R14
-	CMPQ	R13, R14
-	JNE	aligned
+	CMPQ	R14, $0
+	JE	aligned
 	PUSHQ	$0		// ensure 16-byte alignment
 aligned:
 	MOVQ	R13, R14


### PR DESCRIPTION
The current code only checks if N = 1, however it falls through for other odd numbers. Rewriting this to compare against 0 (for the low bit) and otherwise pad the SP.