### PR TITLE
Devicepath hardening and normalize FilePath

### DIFF
--- a/uefi/path.go
+++ b/uefi/path.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"strings"
 
 	"github.com/usbarmory/tamago/dma"
 )
@@ -115,6 +116,11 @@ func (d *FilePath) Bytes() []byte {
 
 // FilePath returns the full EFI Device Path associated with the named file.
 func (root *FS) FilePath(name string) (devicePath []*DevicePath, filePath *FilePath, desc []byte, err error) {
+	name = strings.ReplaceAll(name, "/", "\\")
+	if !strings.HasPrefix(name, "\\") {
+		name = "\\" + name
+	}
+
 	pathName := toUTF16(name)
 
 	filePath = &FilePath{

--- a/uefi/path.go
+++ b/uefi/path.go
@@ -76,7 +76,7 @@ func (root *FS) devicePath() (devicePath []*DevicePath, desc []byte, err error) 
 			break
 		}
 
-		if node.Length == 0 || node.Length > 0xff {
+		if node.Length < 4 || node.Length > 0xff {
 			return nil, nil, errors.New("invalid length")
 		}
 


### PR DESCRIPTION
This PR brings in two changes:

1. Normalize File Paths. Per UEFI Spec 10.3.5.4 file paths needs to be absolute and in backslash form.
2. Reject device-path nodes with Length < 4; A device-path has per spec always at least four bytes: Type, Subtype, Length (2 bytes). 