### PR TITLE
uefi: add LoadImageBuffer, load via it in LoadImage

### DIFF
--- a/uefi/image.go
+++ b/uefi/image.go
@@ -6,6 +6,7 @@
 package uefi
 
 import (
+	"errors"
 	"io/fs"
 )
 
@@ -23,24 +24,7 @@ func (s *BootServices) LoadImage(boot int, root *FS, name string) (imageHandle u
 		return
 	}
 
-	_, _, devicePath, err := root.FilePath(name)
-
-	if err != nil {
-		return
-	}
-
-	status := callService(s.base+loadImage,
-		[]uint64{
-			uint64(boot),
-			s.imageHandle,
-			ptrval(&devicePath[0]),
-			ptrval(&buf[0]),
-			uint64(len(buf)),
-			ptrval(&imageHandle),
-		},
-	)
-
-	return imageHandle, parseStatus(status)
+	return s.LoadImageFrom(root, name, buf)
 }
 
 // StartImage calls EFI_BOOT_SERVICES.StartImage().
@@ -54,4 +38,31 @@ func (s *BootServices) StartImage(imageHandle uint64) (err error) {
 	)
 
 	return parseStatus(status)
+}
+
+// LoadImageFrom calls EFI_BOOT_SERVICES.LoadImage() with a caller-supplied
+// SourceBuffer.
+func (s *BootServices) LoadImageFrom(root *FS, name string, buf []byte) (imageHandle uint64, err error) {
+	if len(buf) == 0 {
+		return 0, errors.New("empty source buffer")
+	}
+
+	_, _, devicePath, err := root.FilePath(name)
+
+	if err != nil {
+		return
+	}
+
+	status := callService(s.base+loadImage,
+		[]uint64{
+			0,
+			s.imageHandle,
+			ptrval(&devicePath[0]),
+			ptrval(&buf[0]),
+			uint64(len(buf)),
+			ptrval(&imageHandle),
+		},
+	)
+
+	return imageHandle, parseStatus(status)
 }


### PR DESCRIPTION
LoadImageBuffer calls EFI_BOOT_SERVICES.LoadImage() with a caller-supplied SourceBuffer instead of reading the named file, so a caller can verify an image and hand the firmware those exact bytes.

LoadImage reads the file and delegates to LoadImageBuffer, removing the duplicated call site.

Small note: LoadImage's boot param is now unused ([BootPolicy is ignored in SourceBuffer mode](https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-loadimage), which go-boot always uses); happy to drop it.