### PR TITLE
uefi: add LocateHandleBuffer and FreePool

### DIFF
--- a/uefi/mem.go
+++ b/uefi/mem.go
@@ -14,6 +14,7 @@ import (
 const (
 	// EFI Boot Services offset for GetMemoryMap
 	getMemoryMap = 0x38
+	freePool     = 0x48
 	maxEntries   = 1000
 )
 
@@ -154,4 +155,11 @@ func (s *BootServices) GetMemoryMap() (m *MemoryMap, err error) {
 	}
 
 	return
+}
+
+// FreePool calls EFI_BOOT_SERVICES.FreePool().
+func (s *BootServices) FreePool(buffer uint64) error {
+	status := callService(s.base+freePool, []uint64{buffer})
+
+	return parseStatus(status)
 }

--- a/uefi/protocol.go
+++ b/uefi/protocol.go
@@ -7,8 +7,16 @@ package uefi
 
 // EFI Boot Services offsets
 const (
-	handleProtocol = 0x098
-	locateProtocol = 0x140
+	handleProtocol     = 0x098
+	locateHandleBuffer = 0x138
+	locateProtocol     = 0x140
+)
+
+// EFI_LOCATE_SEARCH_TYPE values
+const (
+	AllHandles = iota
+	ByRegisterNotify
+	ByProtocol
 )
 
 // HandleProtocol calls EFI_BOOT_SERVICES.HandleProtocol().
@@ -35,4 +43,41 @@ func (s *BootServices) LocateProtocol(guid GUID) (addr uint64, err error) {
 	)
 
 	return addr, parseStatus(status)
+}
+
+// LocateHandleBuffer calls EFI_BOOT_SERVICES.LocateHandleBuffer(), returning the
+// handles matching searchType (for ByProtocol, guid selects the protocol).
+func (s *BootServices) LocateHandleBuffer(searchType uint64, guid GUID) (handles []uint64, err error) {
+	var noHandles uint64
+	var buffer uint64
+
+	status := callService(s.base+locateHandleBuffer,
+		[]uint64{
+			searchType,
+			ptrval(&guid[0]),
+			0,
+			ptrval(&noHandles),
+			ptrval(&buffer),
+		},
+	)
+
+	if err = parseStatus(status); err != nil {
+		return nil, err
+	}
+
+	if noHandles == 0 || buffer == 0 {
+		return nil, nil
+	}
+
+	handles = make([]uint64, noHandles)
+
+	if err = decode(handles, buffer); err != nil {
+		return nil, err
+	}
+
+	if err = s.FreePool(buffer); err != nil {
+		return nil, err
+	}
+
+	return handles, nil
 }


### PR DESCRIPTION
LocateHandleBuffer enumerates the handles carrying a given protocol, returning a Go slice and releasing the firmware buffer via FreePool. It is the basis for per-handle protocol enumeration.

This PR sets the basis for upstreaming `EFI_STORAGE_SECURITY_COMMAND_PROTOCOL` and `EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL`.